### PR TITLE
fix: dont pty.start with control

### DIFF
--- a/_examples/ssh-docker/docker.go
+++ b/_examples/ssh-docker/docker.go
@@ -38,7 +38,7 @@ func main() {
 	})
 
 	log.Println("starting ssh server on port 2222...")
-	log.Fatal(ssh.ListenAndServe(":2222", nil))
+	log.Fatal(ssh.ListenAndServe("localhost:2222", nil))
 }
 
 func dockerRun(cfg *container.Config, sess ssh.Session) (status int64, cleanup func(), err error) {

--- a/_examples/ssh-forwardagent/forwardagent.go
+++ b/_examples/ssh-forwardagent/forwardagent.go
@@ -31,5 +31,5 @@ func main() {
 	})
 
 	log.Println("starting ssh server on port 2222...")
-	log.Fatal(ssh.ListenAndServe(":2222", nil))
+	log.Fatal(ssh.ListenAndServe("localhost:2222", nil))
 }

--- a/_examples/ssh-pty/pty.go
+++ b/_examples/ssh-pty/pty.go
@@ -45,5 +45,5 @@ func main() {
 	})
 
 	log.Println("starting ssh server on port 2222...")
-	log.Fatal(ssh.ListenAndServe(":2222", nil))
+	log.Fatal(ssh.ListenAndServe("localhost:2222", nil))
 }

--- a/_examples/ssh-ptystart/main.go
+++ b/_examples/ssh-ptystart/main.go
@@ -53,7 +53,7 @@ func main() {
 	})
 
 	log.Println("starting ssh server on port 2222...")
-	if err := ssh.ListenAndServe(":2222", nil, ssh.AllocatePty()); err != nil && err != ssh.ErrServerClosed {
+	if err := ssh.ListenAndServe("localhost:2222", nil, ssh.AllocatePty()); err != nil && err != ssh.ErrServerClosed {
 		log.Fatal(err)
 	}
 }

--- a/_examples/ssh-publickey/public_key.go
+++ b/_examples/ssh-publickey/public_key.go
@@ -21,5 +21,5 @@ func main() {
 	})
 
 	log.Println("starting ssh server on port 2222...")
-	log.Fatal(ssh.ListenAndServe(":2222", nil, publicKeyOption))
+	log.Fatal(ssh.ListenAndServe("localhost:2222", nil, publicKeyOption))
 }

--- a/_examples/ssh-remoteforward/portforward.go
+++ b/_examples/ssh-remoteforward/portforward.go
@@ -17,7 +17,7 @@ func main() {
 			log.Println("Accepted forward", dhost, dport)
 			return true
 		}),
-		Addr: ":2222",
+		Addr: "localhost:2222",
 		Handler: ssh.Handler(func(s ssh.Session) {
 			io.WriteString(s, "Remote forwarding available...\n")
 			select {}

--- a/_examples/ssh-simple/simple.go
+++ b/_examples/ssh-simple/simple.go
@@ -14,5 +14,5 @@ func main() {
 	})
 
 	log.Println("starting ssh server on port 2222...")
-	log.Fatal(ssh.ListenAndServe(":2222", nil))
+	log.Fatal(ssh.ListenAndServe("localhost:2222", nil))
 }

--- a/_examples/ssh-timeouts/timeouts.go
+++ b/_examples/ssh-timeouts/timeouts.go
@@ -33,7 +33,7 @@ func main() {
 	log.Printf("connections will only last %s\n", DeadlineTimeout)
 	log.Printf("and timeout after %s of no activity\n", IdleTimeout)
 	server := &ssh.Server{
-		Addr:        ":2222",
+		Addr:        "localhost:2222",
 		MaxTimeout:  DeadlineTimeout,
 		IdleTimeout: IdleTimeout,
 	}

--- a/pty_unix.go
+++ b/pty_unix.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"syscall"
 
 	"github.com/creack/pty"
 	"github.com/u-root/u-root/pkg/termios"
@@ -67,11 +66,6 @@ func (i *impl) Resize(w int, h int) (rErr error) {
 
 func (i *impl) start(c *exec.Cmd) error {
 	c.Stdin, c.Stdout, c.Stderr = i.Slave, i.Slave, i.Slave
-	if c.SysProcAttr == nil {
-		c.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	c.SysProcAttr.Setctty = true
-	c.SysProcAttr.Setsid = true
 	return c.Start()
 }
 


### PR DESCRIPTION
The SSH session should be in control of the PTY, not the command it can eventually run.

This removes the `sectty` bit, as well as `setsid`.