### PR TITLE
fix: session environ should return $TERM

### DIFF
--- a/session.go
+++ b/session.go
@@ -195,7 +195,11 @@ func (sess *session) LocalAddr() net.Addr {
 }
 
 func (sess *session) Environ() []string {
-	return append([]string(nil), sess.env...)
+	env := append([]string(nil), sess.env...)
+	if sess.pty != nil {
+		env = append(env, "TERM="+sess.pty.Term)
+	}
+	return env
 }
 
 func (sess *session) RawCommand() string {


### PR DESCRIPTION
By default, the TERM environment variable is sent separately in the `pry-req` request when the session is a PTY session. Other environment variables have their own request type `env` and get handled separately.

This combines these two and returns a slice that contains TERM and all other sent environment variables.

Refs: https://github.com/charmbracelet/bubbletea/pull/1063