### PR TITLE
docs: replace dead Gliderlabs Slack link with Charm Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CircleCI](https://img.shields.io/circleci/project/github/gliderlabs/ssh.svg)](https://circleci.com/gh/gliderlabs/ssh)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gliderlabs/ssh)](https://goreportcard.com/report/github.com/gliderlabs/ssh) 
 [![OpenCollective](https://opencollective.com/ssh/sponsors/badge.svg)](#sponsors)
-[![Slack](http://slack.gliderlabs.com/badge.svg)](http://slack.gliderlabs.com) 
+[![Discord](https://img.shields.io/discord/473466411696873472?label=discord&logo=discord)](https://charm.land/chat) 
 [![Email Updates](https://img.shields.io/badge/updates-subscribe-yellow.svg)](https://app.convertkit.com/landing_pages/243312)
 
 > The Glider Labs SSH server package is dope.  &mdash;[@bradfitz](https://twitter.com/bradfitz), Go team member
@@ -47,7 +47,7 @@ A bunch of great examples are in the `_examples` directory.
 Pull requests are welcome! However, since this project is very much about API
 design, please submit API changes as issues to discuss before submitting PRs.
 
-Also, you can [join our Slack](http://slack.gliderlabs.com) to discuss as well.
+Also, you can [join our Discord](https://charm.land/chat) to discuss as well.
 
 ## Roadmap
 


### PR DESCRIPTION
Closes #40.

\`slack.gliderlabs.com\` is dead (the host just times out), so both the badge at the top of the README and the \"join our Slack\" line at the bottom went nowhere. Pointed them at \`charm.land/chat\` (the Charm Discord) since that's where the rest of the charmbracelet repos point.

One-line README change, no code touched. The rest of the README still has Gliderlabs branding from before this repo was rehomed — happy to do a follow-up PR cleaning that up too if you'd like, but kept this one tightly scoped to the dead link.