### PR TITLE
feat: Add PROXY protocol

### DIFF
--- a/_examples/ssh-proxy-protocol/proxy_protocol.go
+++ b/_examples/ssh-proxy-protocol/proxy_protocol.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/donovanhubbard/ssh"
+)
+
+const (
+	ADDR = "0.0.0.0:4444"
+)
+
+func main() {
+	ssh.Handle(func(s ssh.Session) {
+		io.WriteString(s, fmt.Sprintf("Your address is %s\n", s.RemoteAddr()))
+	})
+
+	log.Println("starting ssh server on " + ADDR)
+	log.Fatal(ssh.ListenAndServe(ADDR, nil, ssh.EnableProxyProtocol()))
+}

--- a/_examples/ssh-proxy-protocol/proxy_protocol.go
+++ b/_examples/ssh-proxy-protocol/proxy_protocol.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"log"
 
-	"github.com/donovanhubbard/ssh"
+	"github.com/charmbracelet/ssh"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,15 @@
 module github.com/charmbracelet/ssh
 
-go 1.23.0
+go 1.25
 
-toolchain go1.24.1
+toolchain go1.25.0
 
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	github.com/charmbracelet/x/conpty v0.1.0
 	github.com/charmbracelet/x/termios v0.1.0
 	github.com/creack/pty v1.1.21
+	github.com/pires/go-proxyproto v0.12.0
 	golang.org/x/crypto v0.37.0
 	golang.org/x/sys v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -14,3 +14,5 @@ golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
+github.com/pires/go-proxyproto v0.12.0 h1:TTCxD66dU898tahivkqc3hoceZp7P44FnorWyo9d5vM=
+github.com/pires/go-proxyproto v0.12.0/go.mod h1:qUvfqUMEoX7T8g0q7TQLDnhMjdTrxnG0hvpMn+7ePNI=

--- a/options.go
+++ b/options.go
@@ -114,7 +114,7 @@ func AllocatePty() Option {
 // EnableProxyProtocol returns a functional option that sets EnableProxyProtocol on the server
 func EnableProxyProtocol() Option {
 	return func(srv *Server) error {
-		srv.enableProxyProtocol = true
+		srv.EnableProxyProtocol = true
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -110,3 +110,11 @@ func AllocatePty() Option {
 		return nil
 	}
 }
+
+// EnableProxyProtocol returns a functional option that sets EnableProxyProtocol on the server
+func EnableProxyProtocol() Option {
+	return func(srv *Server) error {
+		srv.enableProxyProtocol = true
+		return nil
+	}
+}

--- a/server.go
+++ b/server.go
@@ -68,6 +68,8 @@ type Server struct {
 	IdleTimeout time.Duration // connection timeout when no activity, none if empty
 	MaxTimeout  time.Duration // absolute connection timeout, none if empty
 
+	EnableProxyProtocol bool // Enable support for HA Proxy's and NGinx's PROXY protocol
+
 	// ChannelHandlers allow overriding the built-in session handlers or provide
 	// extensions to the protocol, such as tcpip forwarding. By default only the
 	// "session" handler is enabled.
@@ -88,8 +90,6 @@ type Server struct {
 	conns      map[*gossh.ServerConn]struct{}
 	connWg     sync.WaitGroup
 	doneChan   chan struct{}
-
-	enableProxyProtocol bool // Enable support for HA Proxy's and NGinx's PROXY protocol
 }
 
 func (srv *Server) ensureHostSigner() error {
@@ -276,7 +276,7 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 //
 // Serve always returns a non-nil error.
 func (srv *Server) Serve(l net.Listener) error {
-	if srv.enableProxyProtocol {
+	if srv.EnableProxyProtocol {
 		_, ok := l.(*proxyproto.Listener)
 		if !ok {
 			l = &proxyproto.Listener{Listener: l}

--- a/server.go
+++ b/server.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pires/go-proxyproto"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -87,6 +88,8 @@ type Server struct {
 	conns      map[*gossh.ServerConn]struct{}
 	connWg     sync.WaitGroup
 	doneChan   chan struct{}
+
+	enableProxyProtocol bool // Enable support for HA Proxy's and NGinx's PROXY protocol
 }
 
 func (srv *Server) ensureHostSigner() error {
@@ -273,6 +276,13 @@ func (srv *Server) Shutdown(ctx context.Context) error {
 //
 // Serve always returns a non-nil error.
 func (srv *Server) Serve(l net.Listener) error {
+	if srv.enableProxyProtocol {
+		_, ok := l.(*proxyproto.Listener)
+		if !ok {
+			l = &proxyproto.Listener{Listener: l}
+		}
+	}
+
 	srv.ensureHandlers()
 	defer l.Close()
 	if err := srv.ensureHostSigner(); err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -3,9 +3,17 @@ package ssh
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"net"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/pires/go-proxyproto"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 func TestAddHostKey(t *testing.T) {
@@ -122,5 +130,105 @@ func TestServerClose(t *testing.T) {
 	case <-s.getDoneChan():
 		<-clientDoneChan
 		return
+	}
+}
+
+func TestProxyProtocol(t *testing.T) {
+	const (
+		CORRECT_IP   = "1.1.1.1"
+		CORRECT_PORT = 55555
+	)
+	handlerDone := make(chan struct{})
+	var testResult error
+
+	handler := func(sess Session) {
+		defer close(handlerDone)
+		sourceAddress := sess.RemoteAddr()
+
+		index := strings.Index(sourceAddress.String(), ":")
+		ip := sourceAddress.String()[:index]
+		portStr := sourceAddress.String()[index+1:]
+
+		if ip != CORRECT_IP {
+			errorMsg := fmt.Sprintf("Expected source address '%s' but got '%s'", CORRECT_IP, ip)
+			testResult = errors.Join(testResult, fmt.Errorf("%s", errorMsg))
+		}
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			testResult = errors.Join(testResult, fmt.Errorf("%s", err))
+		} else if port != CORRECT_PORT {
+			errorMsg := fmt.Sprintf("Expected source port '%d' but got '%d'", CORRECT_PORT, port)
+			testResult = errors.Join(testResult, fmt.Errorf("%s", errorMsg))
+		}
+	}
+
+	// Bind the port before starting the goroutine so net.Dial never races
+	// with the server not yet listening.
+	l := newLocalListener()
+	srv := &Server{Handler: handler}
+	srv.SetOption(EnableProxyProtocol())
+
+	serverDone := make(chan error, 1)
+
+	go func() {
+		serverDone <- srv.Serve(l)
+	}()
+
+	defer func() {
+		srv.Close()
+		if err := <-serverDone; err != nil && err != ErrServerClosed {
+			t.Error(err)
+		}
+	}()
+
+	serverIP, serverPortStr, _ := net.SplitHostPort(l.Addr().String())
+	serverPort, _ := strconv.Atoi(serverPortStr)
+	conn, err := net.Dial("tcp", l.Addr().String())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := &proxyproto.Header{
+		Version:           1,
+		Command:           proxyproto.PROXY,
+		TransportProtocol: proxyproto.TCPv4,
+		SourceAddr: &net.TCPAddr{
+			IP:   net.ParseIP(CORRECT_IP),
+			Port: CORRECT_PORT,
+		},
+		DestinationAddr: &net.TCPAddr{
+			IP:   net.ParseIP(serverIP),
+			Port: serverPort,
+		},
+	}
+
+	// Writes the PROXY header to the TCP stream before SSH begins
+	_, err = header.WriteTo(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hand the same conn to the SSH stack — handshake starts from here.
+	clientConn, chans, reqs, err := gossh.NewClientConn(conn, l.Addr().String(), &gossh.ClientConfig{
+		User:            "testuser",
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := gossh.NewClient(clientConn, chans, reqs)
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.Run("") // triggers the handler; ignore exec error
+
+	<-handlerDone
+
+	if testResult != nil {
+		t.Fatal(testResult)
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -133,7 +133,7 @@ func TestServerClose(t *testing.T) {
 	}
 }
 
-func TestProxyProtocol(t *testing.T) {
+func TestProxyProtocolEnabled(t *testing.T) {
 	const (
 		CORRECT_IP   = "1.1.1.1"
 		CORRECT_PORT = 55555
@@ -196,6 +196,106 @@ func TestProxyProtocol(t *testing.T) {
 		SourceAddr: &net.TCPAddr{
 			IP:   net.ParseIP(CORRECT_IP),
 			Port: CORRECT_PORT,
+		},
+		DestinationAddr: &net.TCPAddr{
+			IP:   net.ParseIP(serverIP),
+			Port: serverPort,
+		},
+	}
+
+	// Writes the PROXY header to the TCP stream before SSH begins
+	_, err = header.WriteTo(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hand the same conn to the SSH stack — handshake starts from here.
+	clientConn, chans, reqs, err := gossh.NewClientConn(conn, l.Addr().String(), &gossh.ClientConfig{
+		User:            "testuser",
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := gossh.NewClient(clientConn, chans, reqs)
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.Run("") // triggers the handler; ignore exec error
+
+	<-handlerDone
+
+	if testResult != nil {
+		t.Fatal(testResult)
+	}
+}
+
+func TestProxyProtocolDisabled(t *testing.T) {
+	const (
+		INCORRECT_IP   = "1.1.1.1"
+		INCORRECT_PORT = 55555
+	)
+	handlerDone := make(chan struct{})
+	var testResult error
+
+	handler := func(sess Session) {
+		defer close(handlerDone)
+		sourceAddress := sess.RemoteAddr()
+
+		index := strings.Index(sourceAddress.String(), ":")
+		ip := sourceAddress.String()[:index]
+		portStr := sourceAddress.String()[index+1:]
+
+		if ip == INCORRECT_IP {
+			errorMsg := fmt.Sprintf("Expected source address to be anything but '%s' but got '%s'", INCORRECT_IP, ip)
+			testResult = errors.Join(testResult, fmt.Errorf("%s", errorMsg))
+		}
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			testResult = errors.Join(testResult, fmt.Errorf("%s", err))
+		} else if port == INCORRECT_PORT {
+			errorMsg := fmt.Sprintf("Expected source port anything but '%d' but got '%d'", INCORRECT_PORT, port)
+			testResult = errors.Join(testResult, fmt.Errorf("%s", errorMsg))
+		}
+	}
+
+	// Bind the port before starting the goroutine so net.Dial never races
+	// with the server not yet listening.
+	l := newLocalListener()
+	srv := &Server{Handler: handler}
+
+	serverDone := make(chan error, 1)
+
+	go func() {
+		serverDone <- srv.Serve(l)
+	}()
+
+	defer func() {
+		srv.Close()
+		if err := <-serverDone; err != nil && err != ErrServerClosed {
+			t.Error(err)
+		}
+	}()
+
+	serverIP, serverPortStr, _ := net.SplitHostPort(l.Addr().String())
+	serverPort, _ := strconv.Atoi(serverPortStr)
+	conn, err := net.Dial("tcp", l.Addr().String())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Set the PROXY header information. The server should not read it
+	header := &proxyproto.Header{
+		Version:           1,
+		Command:           proxyproto.PROXY,
+		TransportProtocol: proxyproto.TCPv4,
+		SourceAddr: &net.TCPAddr{
+			IP:   net.ParseIP(INCORRECT_IP),
+			Port: INCORRECT_PORT,
 		},
 		DestinationAddr: &net.TCPAddr{
 			IP:   net.ParseIP(serverIP),


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

In 2011 the people working on HA Proxy developed what would be known as the PROXY protocol. This solved the problem of how upstream load balancers and proxies could pass information about the original client's IP address and port to the backend server.

In order to take advantage of the PROXY protocol, the load balancer must send the PROXY header and the backend server needs to be able to read the header. The protocol is supported by a wide variety of load balancers including:

HA Proxy
nginx
Amazon Application Load Balancers
Traefik
Envoy
Cloudflare

This pull request adds support for the PROXY protocol to the ssh server via a new option called EnableProxyProtocol. An example has been included in the _examples directory.

This is accomplished through the https://github.com/pires/go-proxyproto library. It replaces the information returned by the ssh.Session object's RemoteAdd() function with the requestor's original IP address and port and not the load balancer's load balancer and port which is what would be displayed without this protocol.

This was discussed in https://github.com/charmbracelet/ssh/issues/43

It's a fairly simple code change. I've been running my own fork of this for several weeks with no problems.

However, the package I'm using has a minimum supported go version of `1.25` which is a change from the forks current version of `1.23`. For reference go `1.24` ended support in Feb 11, 2026. I don't know if that will be a problem for you or not. 